### PR TITLE
test: fork always from latest block

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -58,10 +58,6 @@ jobs:
 
       - name: Test contract
         run: npx hardhat test
-        env:
-          POLYGON_URL: ${{ secrets.POLYGON_URL }}
 
       - name: Deploy contract
         run: npx hardhat --network hardhat run ./scripts/deployOffsetHelper.ts
-        env:
-          POLYGON_URL: ${{ secrets.POLYGON_URL }}

--- a/hardhat.config.ts
+++ b/hardhat.config.ts
@@ -48,7 +48,6 @@ const config: HardhatUserConfig = {
       forking: {
         url:
           process.env.POLYGON_URL || "",
-        blockNumber: 25848203,
       },
     },
   },


### PR DESCRIPTION
This change has two advantages:
* we always test with the latest version of
the live Toucan core contracts
* we don't need to maintain a Github secret
which is does not work with PRs that originate
from forks