### PR TITLE
PRT-212: calculate token amount method

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ A collection of examples that implement, integrate with or otherwise use Toucan'
 
 | Contract     | Polygon                                                                                                                  | Mumbai                                                                                                                          |
 | ------------ | ------------------------------------------------------------------------------------------------------------------------ | ------------------------------------------------------------------------------------------------------------------------------- |
-| OffsetHelper | [0x2E730e699D6c5A9F7dF40E6D7cbB82638d56dF6B](https://polygonscan.com/address/0x2E730e699D6c5A9F7dF40E6D7cbB82638d56dF6B) | [0x1b5e0afaDAcC6D4631C94bF35D3e3F4d60ad8323](https://mumbai.polygonscan.com/address/0x1b5e0afaDAcC6D4631C94bF35D3e3F4d60ad8323) |
+| OffsetHelper | [0x7229F708d2d1C29b1508E35695a3070F55BbA479](https://polygonscan.com/address/0x7229F708d2d1C29b1508E35695a3070F55BbA479) | [0xE0a1D62C84f7Ca4611C0ada6cfC3E9187a7A97e6](https://mumbai.polygonscan.com/address/0xE0a1D62C84f7Ca4611C0ada6cfC3E9187a7A97e6) |
 
 ## OffsetHelper
 
@@ -28,9 +28,9 @@ If you call the `autoOffset()` method specifying only 2 params, it will be payab
 
 The first param is the pool token you want the contract to use (could be NCT or BCT) and the second is the amount of TCO2 to retire.
 
-In case you send too much MATIC in the `msg.value`, the contract is programed to send leftover MATIC back to the user. But, I suggest you use the `howMuchETHShouldISendToSwap()` method of the contract before calling `autoOffset()` in this case.
+In case you send too much MATIC in the `msg.value`, the contract is programed to send leftover MATIC back to the user. But, I suggest you use the `calculateNeededETHAmount()` method of the contract before calling `autoOffset()` in this case.
 
-We'll discuss the `howMuchETHShouldISendToSwap()` method below.
+We'll discuss the `calculateNeededETHAmount()` method below.
 
 ### `autoOffsetUsingPoolToken(address _poolToken, uint256 _amountToOffset)`
 
@@ -42,7 +42,7 @@ The first parameter is the pool token you will deposit to do the offset (could b
 
 You will want to approve the `OffsetHelper` from the token you wish to deposit before calling `autoOffsetUsingPoolToken()` in this case.
 
-### `howMuchETHShouldISendToSwap(address _toToken, uint256 _amount)`
+### `calculateNeededETHAmount(address _toToken, uint256 _amount)`
 
 This is a view method that allows you to see how much MATIC it would cost you to get a certain amount of BCT / NCT.
 

--- a/contracts/test/Swapper.sol
+++ b/contracts/test/Swapper.sol
@@ -20,7 +20,7 @@ contract Swapper {
         }
     }
 
-    function howMuchETHShouldISendToSwap(address _toToken, uint256 _amount)
+    function calculateNeededETHAmount(address _toToken, uint256 _amount)
         public
         view
         returns (uint256)

--- a/test/OffsetHelper.ts
+++ b/test/OffsetHelper.ts
@@ -93,21 +93,21 @@ describe("Offset Helper - autoOffset", function () {
     );
 
     await swapper.swap(addresses.weth, parseEther("20.0"), {
-      value: await swapper.howMuchETHShouldISendToSwap(
+      value: await swapper.calculateNeededETHAmount(
         addresses.weth,
         parseEther("20.0")
       ),
     });
 
     await swapper.swap(addresses.bct, parseEther("50.0"), {
-      value: await swapper.howMuchETHShouldISendToSwap(
+      value: await swapper.calculateNeededETHAmount(
         addresses.bct,
         parseEther("50.0")
       ),
     });
 
     await swapper.swap(addresses.nct, parseEther("50.0"), {
-      value: await swapper.howMuchETHShouldISendToSwap(
+      value: await swapper.calculateNeededETHAmount(
         addresses.nct,
         parseEther("50.0")
       ),
@@ -117,7 +117,14 @@ describe("Offset Helper - autoOffset", function () {
   describe("Testing autoOffset()", function () {
     it("Should retire using a WETH swap and NCT redemption", async function () {
       await (
-        await weth.approve(offsetHelper.address, parseEther("1.0"))
+        await weth.approve(
+          offsetHelper.address,
+          await offsetHelper.calculateNeededTokenAmount(
+            addresses.weth,
+            addresses.nct,
+            parseEther("1.0")
+          )
+        )
       ).wait();
 
       await expect(
@@ -130,7 +137,7 @@ describe("Offset Helper - autoOffset", function () {
     });
 
     it("Should retire using a MATIC swap and NCT redemption", async function () {
-      const maticToSend = await offsetHelper.howMuchETHShouldISendToSwap(
+      const maticToSend = await offsetHelper.calculateNeededETHAmount(
         addresses.nct,
         parseEther("1.0")
       );
@@ -152,7 +159,14 @@ describe("Offset Helper - autoOffset", function () {
 
     it("Should retire using a WETH swap and BCT redemption", async function () {
       await (
-        await weth.approve(offsetHelper.address, parseEther("1.0"))
+        await weth.approve(
+          offsetHelper.address,
+          await offsetHelper.calculateNeededTokenAmount(
+            addresses.weth,
+            addresses.bct,
+            parseEther("1.0")
+          )
+        )
       ).wait();
 
       await expect(
@@ -327,7 +341,14 @@ describe("Offset Helper - autoOffset", function () {
       const initialBalance = await nct.balanceOf(offsetHelper.address);
 
       await (
-        await weth.approve(offsetHelper.address, parseEther("1.0"))
+        await weth.approve(
+          offsetHelper.address,
+          await offsetHelper.calculateNeededTokenAmount(
+            addresses.weth,
+            addresses.nct,
+            parseEther("1.0")
+          )
+        )
       ).wait();
 
       await (
@@ -351,7 +372,7 @@ describe("Offset Helper - autoOffset", function () {
     });
 
     it("Should swap MATIC for 1.0 NCT", async function () {
-      const maticToSend = await offsetHelper.howMuchETHShouldISendToSwap(
+      const maticToSend = await offsetHelper.calculateNeededETHAmount(
         addresses.nct,
         parseEther("1.0")
       );
@@ -375,7 +396,7 @@ describe("Offset Helper - autoOffset", function () {
         offsetHelper.address
       );
 
-      const maticToSend = await offsetHelper.howMuchETHShouldISendToSwap(
+      const maticToSend = await offsetHelper.calculateNeededETHAmount(
         addresses.nct,
         parseEther("1.0")
       );
@@ -422,9 +443,13 @@ describe("Offset Helper - autoOffset", function () {
     it("Should swap WETH for 1.0 BCT", async function () {
       const initialBalance = await bct.balanceOf(offsetHelper.address);
 
-      await (
-        await weth.approve(offsetHelper.address, parseEther("1.0"))
-      ).wait();
+      const neededAmount = await offsetHelper.calculateNeededTokenAmount(
+        addresses.weth,
+        addresses.bct,
+        parseEther("1.0")
+      );
+
+      await (await weth.approve(offsetHelper.address, neededAmount)).wait();
 
       await (
         await offsetHelper["swap(address,address,uint256)"](


### PR DESCRIPTION
While working on PRT-198 I realised we need a method to calculate the token amount needed to swap to NCT and redeem+retire in the same manner we have the howMuchETHShouldISendToSwap method that calculates the amount of ETH to send.

While working on this PR (PRT-212) I realised there was an issue with the swap.

Because there was no method to calculate the needed tokens, the code could break since approval and SafeTransferFrom in the swap method was done 'blindly'.

It really only passed tests because I was using weth so the approved amount was always larger than needed, but it could have created cases were bugs happened.

P.S.: I have opened PRT-214 to refactor this as it's quite messy, but I am focused on the SDK right now.

P.P.S.: I have opened PRT-215 to write USDC and WMATIC tests.