### PR TITLE
Docs: Improve readme and autogenerate natspec doc

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -61,6 +61,9 @@ jobs:
         env:
           POLYGON_URL: ${{ secrets.POLYGON_URL }}
 
+      - name: Test solidity-docgen builds
+        run: yarn doc
+
       - name: Deploy contract
         run: yarn hardhat --network hardhat deployOffsetHelper --verify false
         env:

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Install the requirements:
 yarn install
 ```
 
-Generate the documentation using
+Generate documentation from the contract's [natspec](https://docs.soliditylang.org/en/latest/natspec-format.html) comments in [./docs/](./docs/) using
 ```
 npx hardhat docgen
 ```

--- a/README.md
+++ b/README.md
@@ -10,21 +10,9 @@ A collection of Solidity contract examples that implement, integrate with or dem
 
 ## OffsetHelper
 
-The `OffsetHelper` contract implements helper functions that simplify the carbon offsetting (retirement) process. Retiring carbon tokens normally requires multiple steps and interactions with Toucan Protocol's main contracts:
-1. Obtain a Toucan pool token such as BCT or NCT (by performing a token swap).
-2. Redeem the pool token for a TCO2 token.
-3. Retire the TCO2 token.
+The `OffsetHelper` contract implements helper functions that simplify the carbon offsetting (retirement) process.
 
-These steps are combined in each of the following "auto offset" methods implemented in `OffsetHelper` to allow a retirement within one transaction:
-- `autoOffsetUsingPoolToken()` if the user has already owns a Toucan pool token such as BCT or NCT,
-- `autoOffsetUsingETH()` if the user would like to perform a retirement using MATIC,
-- `autoOffsetUsingToken()` if the user would like to perform a retirement using an ERC20 token: USDC, WETH or WMATIC.
-
-In these methods, "auto" refers to the fact that these methods use `autoRedeem` in order to automatically choose a TCO2 token corresponding to the oldest tokenized carbon project in the specfified token pool. There are no fees incurred by the user when using `autoRedeem`.
-
-There are two read helper functions `calculateNeededETHAmount()` and `calculateNeededTokenAmount()` that can be used before calling `autoOffsetUsingETH()` and `autoOffsetUsingToken()`, to determine how MATIC, respectively how much of the ERC20 token must be sent to the `OffsetHelper` contract in order to retire the specified amount of carbon. 
-
-See [./docs/OffsetHelper.md](./docs/OffsetHelper.md) for detailed documentation of these and other methods from the contract.
+See [./docs/OffsetHelper.md](./docs/OffsetHelper.md) for detailed documentation.
 
 ### Development
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Example Implementations
 
-A collection of Solidity contract examples that implement, integrate with or demonstrate the use of Toucan's contracts and infrastructure. Some of these may be used in production.
+A collection of Solidity contract examples that integrate with or demonstrate the use of Toucan's contracts and infrastructure. Some of these may be used in production.
 
 ## Contracts
 
@@ -16,12 +16,33 @@ See [./docs/OffsetHelper.md](./docs/OffsetHelper.md) for detailed documentation.
 
 ### Development
 
-Install the requirements:
+## Preqrequisites
+
+1. Install the required packages:
+   ```
+   yarn
+   ```
+2. Copy `.env.example` to `.env` and modify values of the required environment variables: 
+   1. `POLYGON_URL`/`MUMBAI_URL` to specify custom RPC endpoints for Polygon Mainnet, respectively, the Mumbai Testnet.  
+   2. `PRIVATE_KEY` and `POLYGONSCAN_KEY` in order to deploy contract and publish source code on [polygonscan](https://polygonscan.com).
+
+## Commands
+
+Use the following commands to compile, test and deploy the contracts:
 ```
-yarn install
+yarn compile
+yarn test      # test using a polygon fork
+yarn coverage  # test using a polygon fork with coverage report
+yarn deploy
 ```
 
-Generate documentation from the contract's [natspec](https://docs.soliditylang.org/en/latest/natspec-format.html) comments in [./docs/](./docs/) using
+Documentation can be auto-generated from the contract's [natspec](https://docs.soliditylang.org/en/latest/natspec-format.html) in [./docs/](./docs/) using
 ```
-npx hardhat docgen
+yarn doc
 ```
+
+Deploy the contract locally with:
+```
+yarn hardhat --network hardhat deployOffsetHelper --verify false
+```
+

--- a/contracts/OffsetHelper.sol
+++ b/contracts/OffsetHelper.sol
@@ -34,11 +34,12 @@ contract OffsetHelper is OffsetHelperStorage {
         uint256[] amounts
     );
 
-    // @description this is the autoOffset method for when the user wants to input tokens like USDC, WETH, WMATIC
-    // @param _depositedToken the address of the token that the user sends (could be USDC, WETH, WMATIC)
-    // @param _poolToken the pool that the user wants to use (could be NCT or BCT)
-    // @param _amountToOffset the amount of TCO2 to offset
-    // @returns 2 arrays, one containing the tco2s that were redeemed and another the amounts
+    /// @notice this is the autoOffset method for when the user wants to input tokens like USDC, WETH, WMATIC
+    /// @param _depositedToken the address of the token that the user sends (could be USDC, WETH, WMATIC)
+    /// @param _poolToken the pool that the user wants to use (could be NCT or BCT)
+    /// @param _amountToOffset the amount of TCO2 to offset
+    /// @return tco2s an array of the tco2 addresses that were redeemed
+    /// @return amounts an array of the amounts of each tco2s that were redeemed
     function autoOffsetUsingToken(
         address _depositedToken,
         address _poolToken,
@@ -54,9 +55,9 @@ contract OffsetHelper is OffsetHelperStorage {
         autoRetire(tco2s, amounts);
     }
 
-    // @description this is the autoOffset method for when the user wants to input MATIC
-    // @param _poolToken the pool that the user wants to use (could be NCT or BCT)
-    // @param _amountToOffset the amount of TCO2 to offset
+    /// @notice this is the autoOffset method for when the user wants to input MATIC
+    /// @param _poolToken the pool that the user wants to use (could be NCT or BCT)
+    /// @param _amountToOffset the amount of TCO2 to offset
     function autoOffsetUsingETH(address _poolToken, uint256 _amountToOffset)
         public
         payable
@@ -72,9 +73,9 @@ contract OffsetHelper is OffsetHelperStorage {
         autoRetire(tco2s, amounts);
     }
 
-    // @description this is the autoOffset method for when the user already has and wants to input BCT / NCT
-    // @param _poolToken the pool token that the user wants to use (could be NCT or BCT)
-    // @param _amountToOffset the amount of TCO2 to offset
+    /// @notice this is the autoOffset method for when the user already has and wants to input BCT / NCT
+    /// @param _poolToken the pool token that the user wants to use (could be NCT or BCT)
+    /// @param _amountToOffset the amount of TCO2 to offset
     function autoOffsetUsingPoolToken(
         address _poolToken,
         uint256 _amountToOffset
@@ -90,7 +91,7 @@ contract OffsetHelper is OffsetHelperStorage {
     }
 
     // checks address and returns if can be used at all by the contract
-    // @param _erc20Address address of token to be checked
+    /// @param _erc20Address address of token to be checked
     function isEligible(address _erc20Address) private view returns (bool) {
         bool isToucanContract = IToucanContractRegistry(contractRegistryAddress)
             .checkERC20(_erc20Address);
@@ -104,7 +105,7 @@ contract OffsetHelper is OffsetHelperStorage {
     }
 
     // checks address and returns if it can be used in a swap
-    // @param _erc20Address address of token to be checked
+    /// @param _erc20Address address of token to be checked
     function isSwapable(address _erc20Address) private view returns (bool) {
         if (_erc20Address == eligibleTokenAddresses["USDC"]) return true;
         if (_erc20Address == eligibleTokenAddresses["WETH"]) return true;
@@ -113,18 +114,18 @@ contract OffsetHelper is OffsetHelperStorage {
     }
 
     // checks address and returns if can it's a pool token and can be redeemed
-    // @param _erc20Address address of token to be checked
+    /// @param _erc20Address address of token to be checked
     function isRedeemable(address _erc20Address) private view returns (bool) {
         if (_erc20Address == eligibleTokenAddresses["BCT"]) return true;
         if (_erc20Address == eligibleTokenAddresses["NCT"]) return true;
         return false;
     }
 
-    // @description tells user how much of _fromToken is required to swap for an amount of pool tokens
-    // @param _fromToken the token the user wants to swap for pool token
-    // @param _toToken token to swap for (should be NCT or BCT)
-    // @param _amount amount of NCT / BCT wanted
-    // @returns uint256 representing the required ETH / MATIC to get the amount of NCT / BCT
+    /// @notice tells user how much of _fromToken is required to swap for an amount of pool tokens
+    /// @param _fromToken the token the user wants to swap for pool token
+    /// @param _toToken token to swap for (should be NCT or BCT)
+    /// @param _amount amount of NCT / BCT wanted
+    /// @return amountsIn the amount required ETH / MATIC to get the amount of NCT / BCT
     function calculateNeededTokenAmount(
         address _fromToken,
         address _toToken,
@@ -150,11 +151,11 @@ contract OffsetHelper is OffsetHelperStorage {
         return amountsIn[0];
     }
 
-    // @description uses SushiSwap to exchange eligible tokens for BCT / NCT
-    // @param _fromToken token to deposit and swap
-    // @param _toToken token to swap for (will be held within contract)
-    // @param _amount amount of NCT / BCT wanted
-    // @notice needs to be approved on the client side
+    /// @notice uses SushiSwap to exchange eligible tokens for BCT / NCT
+    /// @param _fromToken token to deposit and swap
+    /// @param _toToken token to swap for (will be held within contract)
+    /// @param _amount amount of NCT / BCT wanted
+    /// @notice needs to be approved on the client side
     function swap(
         address _fromToken,
         address _toToken,
@@ -210,10 +211,10 @@ contract OffsetHelper is OffsetHelperStorage {
 
     receive() external payable {}
 
-    // @description tells user how much ETH/MATIC is required to swap for an amount of pool tokens
-    // @param _toToken token to swap for (should be NCT or BCT)
-    // @param _amount amount of NCT / BCT wanted
-    // @returns uint256 representing the required ETH / MATIC to get the amount of NCT / BCT
+    /// @notice tells user how much ETH/MATIC is required to swap for an amount of pool tokens
+    /// @param _toToken token to swap for (should be NCT or BCT)
+    /// @param _amount amount of NCT / BCT wanted
+    /// @return amountsIn the amount required ETH / MATIC to get the amount of NCT / BCT
     function calculateNeededETHAmount(address _toToken, uint256 _amount)
         public
         view
@@ -236,10 +237,10 @@ contract OffsetHelper is OffsetHelperStorage {
         return amounts[0];
     }
 
-    // @description uses SushiSwap to exchange MATIC for BCT / NCT
-    // @param _toToken token to swap for (will be held within contract)
-    // @param _amount amount of NCT / BCT wanted
-    // @notice needs to be provided a message value on client side
+    /// @notice uses SushiSwap to exchange MATIC for BCT / NCT
+    /// @param _toToken token to swap for (will be held within contract)
+    /// @param _amount amount of NCT / BCT wanted
+    /// @notice needs to be provided a message value on client side
     function swap(address _toToken, uint256 _amount) public payable {
         // check tokens
         require(isRedeemable(_toToken), "Token not eligible");
@@ -281,7 +282,7 @@ contract OffsetHelper is OffsetHelperStorage {
         balances[msg.sender][path[2]] += _amount;
     }
 
-    // @description allow users to withdraw tokens they have deposited
+    /// @notice allow users to withdraw tokens they have deposited
     function withdraw(address _erc20Addr, uint256 _amount) public {
         require(
             balances[msg.sender][_erc20Addr] >= _amount,
@@ -292,8 +293,8 @@ contract OffsetHelper is OffsetHelperStorage {
         balances[msg.sender][_erc20Addr] -= _amount;
     }
 
-    // @description allow people to deposit BCT / NCT
-    // @notice needs to be approved
+    /// @notice allow people to deposit BCT / NCT
+    /// @notice needs to be approved
     function deposit(address _erc20Addr, uint256 _amount) public {
         require(isRedeemable(_erc20Addr), "Token not eligible");
 
@@ -301,11 +302,12 @@ contract OffsetHelper is OffsetHelperStorage {
         balances[msg.sender][_erc20Addr] += _amount;
     }
 
-    // @description redeems an amount of NCT / BCT for TCO2
-    // @param _fromToken could be the address of NCT or BCT
-    // @param _amount amount to redeem
-    // @notice needs to be approved on the client side
-    // @returns 2 arrays, one containing the tco2s that were redeemed and another the amounts
+    /// @notice redeems an amount of NCT / BCT for TCO2
+    /// @param _fromToken could be the address of NCT or BCT
+    /// @param _amount amount to redeem
+    /// @notice needs to be approved on the client side
+    /// @return tco2s an array of the tco2 addresses that were redeemed
+    /// @return amounts an array of the amounts of each tco2s that were redeemed
     function autoRedeem(address _fromToken, uint256 _amount)
         public
         returns (address[] memory tco2s, uint256[] memory amounts)
@@ -333,8 +335,8 @@ contract OffsetHelper is OffsetHelperStorage {
         emit Redeemed(msg.sender, _fromToken, tco2s, amounts);
     }
 
-    // @param _tco2s the addresses of the TCO2s to retire
-    // @param _amounts the amounts to retire from the matching TCO2
+    /// @param _tco2s the addresses of the TCO2s to retire
+    /// @param _amounts the amounts to retire from the matching TCO2
     function autoRetire(address[] memory _tco2s, uint256[] memory _amounts)
         public
     {
@@ -364,9 +366,9 @@ contract OffsetHelper is OffsetHelperStorage {
     //  Admin methods
     // ----------------------------------------
 
-    // @description you can use this to change or add eligible tokens and their addresses if needed
-    // @param _tokenSymbol symbol of the token to add
-    // @param _address the address of the token to add
+    /// @notice you can use this to change or add eligible tokens and their addresses if needed
+    /// @param _tokenSymbol symbol of the token to add
+    /// @param _address the address of the token to add
     function setEligibleTokenAddress(
         string memory _tokenSymbol,
         address _address
@@ -374,8 +376,8 @@ contract OffsetHelper is OffsetHelperStorage {
         eligibleTokenAddresses[_tokenSymbol] = _address;
     }
 
-    // @description you can use this to delete eligible tokens  if needed
-    // @param _tokenSymbol symbol of the token to add
+    /// @notice you can use this to delete eligible tokens  if needed
+    /// @param _tokenSymbol symbol of the token to add
     function deleteEligibleTokenAddress(string memory _tokenSymbol)
         public
         virtual
@@ -384,8 +386,8 @@ contract OffsetHelper is OffsetHelperStorage {
         delete eligibleTokenAddresses[_tokenSymbol];
     }
 
-    // @description you can use this to change the TCO2 contracts registry if needed
-    // @param _address the contract registry to use
+    /// @notice you can use this to change the TCO2 contracts registry if needed
+    /// @param _address the contract registry to use
     function setToucanContractRegistry(address _address)
         public
         virtual

--- a/contracts/OffsetHelper.sol
+++ b/contracts/OffsetHelper.sol
@@ -59,6 +59,16 @@ contract OffsetHelper is OffsetHelperStorage {
         }
     }
 
+    /**
+     * @notice Emitted upon successful redemption of TCO2 tokens from a Toucan
+     * pool token such as BCT or NCT.
+     *
+     * @param who The sender of the transaction
+     * @param poolToken The address of the Toucan pool token used in the
+     * redemption, for example, NCT or BCT
+     * @param tco2s An array of the TCO2 addresses that were redeemed
+     * @param amounts An array of the amounts of each TCO2 that were redeemed
+     */
     event Redeemed(
         address who,
         address poolToken,
@@ -91,7 +101,7 @@ contract OffsetHelper is OffsetHelperStorage {
      * @param _amountToOffset The amount of TCO2 to offset
      *
      * @return tco2s An array of the TCO2 addresses that were redeemed
-     * @return amounts An array of the amounts of each TCO2s that were redeemed
+     * @return amounts An array of the amounts of each TCO2 that were redeemed
      */
     function autoOffsetUsingToken(
         address _depositedToken,
@@ -127,7 +137,7 @@ contract OffsetHelper is OffsetHelperStorage {
      * @param _amountToOffset The amount of TCO2 to offset.
      *
      * @return tco2s An array of the TCO2 addresses that were redeemed
-     * @return amounts An array of the amounts of each TCO2s that were redeemed
+     * @return amounts An array of the amounts of each TCO2 that were redeemed
      */
     function autoOffsetUsingETH(address _poolToken, uint256 _amountToOffset)
         public
@@ -159,7 +169,7 @@ contract OffsetHelper is OffsetHelperStorage {
      * @param _amountToOffset The amount of TCO2 to offset.
      *
      * @return tco2s An array of the TCO2 addresses that were redeemed
-     * @return amounts An array of the amounts of each TCO2s that were redeemed
+     * @return amounts An array of the amounts of each TCO2 that were redeemed
      */
     function autoOffsetUsingPoolToken(
         address _poolToken,
@@ -175,8 +185,9 @@ contract OffsetHelper is OffsetHelperStorage {
         autoRetire(tco2s, amounts);
     }
 
-    // checks address and returns if can be used at all by the contract
-    /// @param _erc20Address address of token to be checked
+    /// @notice Checks whether an address can be used by the contract.
+    /// @param _erc20Address address of the ERC20 token to be checked
+    /// @return True if the address can be used by the contract
     function isEligible(address _erc20Address) private view returns (bool) {
         bool isToucanContract = IToucanContractRegistry(contractRegistryAddress)
             .checkERC20(_erc20Address);
@@ -189,8 +200,9 @@ contract OffsetHelper is OffsetHelperStorage {
         return false;
     }
 
-    // checks address and returns if it can be used in a swap
+    /// @notice Checks whether an address can be used in a token swap
     /// @param _erc20Address address of token to be checked
+    /// @return True if the specified address can be used in a swap
     function isSwapable(address _erc20Address) private view returns (bool) {
         if (_erc20Address == eligibleTokenAddresses["USDC"]) return true;
         if (_erc20Address == eligibleTokenAddresses["WETH"]) return true;
@@ -198,8 +210,9 @@ contract OffsetHelper is OffsetHelperStorage {
         return false;
     }
 
-    // checks address and returns if can it's a pool token and can be redeemed
+    /// @notice Checks whether an address is a Toucan pool token address
     /// @param _erc20Address address of token to be checked
+    /// @return True if the address is a Toucan pool token address
     function isRedeemable(address _erc20Address) private view returns (bool) {
         if (_erc20Address == eligibleTokenAddresses["BCT"]) return true;
         if (_erc20Address == eligibleTokenAddresses["NCT"]) return true;
@@ -400,12 +413,12 @@ contract OffsetHelper is OffsetHelperStorage {
         balances[msg.sender][_erc20Addr] += _amount;
     }
 
-    /// @notice redeems an amount of NCT / BCT for TCO2
+    /// @notice Redeems the specified amount of NCT / BCT for TCO2
     /// @param _fromToken could be the address of NCT or BCT
     /// @param _amount amount to redeem
     /// @notice needs to be approved on the client side
-    /// @return tco2s an array of the tco2 addresses that were redeemed
-    /// @return amounts an array of the amounts of each tco2s that were redeemed
+    /// @return tco2s an array of the TCO2 addresses that were redeemed
+    /// @return amounts an array of the amounts of each TCO2 that were redeemed
     function autoRedeem(address _fromToken, uint256 _amount)
         public
         returns (address[] memory tco2s, uint256[] memory amounts)
@@ -433,6 +446,7 @@ contract OffsetHelper is OffsetHelperStorage {
         emit Redeemed(msg.sender, _fromToken, tco2s, amounts);
     }
 
+    /// @notice Retire the specified TCO2 tokens.
     /// @param _tco2s the addresses of the TCO2s to retire
     /// @param _amounts the amounts to retire from the matching TCO2
     function autoRetire(address[] memory _tco2s, uint256[] memory _amounts)

--- a/contracts/OffsetHelper.sol
+++ b/contracts/OffsetHelper.sol
@@ -185,9 +185,11 @@ contract OffsetHelper is OffsetHelperStorage {
         autoRetire(tco2s, amounts);
     }
 
-    /// @notice Checks whether an address can be used by the contract.
-    /// @param _erc20Address address of the ERC20 token to be checked
-    /// @return True if the address can be used by the contract
+    /**
+     * @notice Checks whether an address can be used by the contract.
+     * @param _erc20Address address of the ERC20 token to be checked
+     * @return True if the address can be used by the contract
+     */
     function isEligible(address _erc20Address) private view returns (bool) {
         bool isToucanContract = IToucanContractRegistry(contractRegistryAddress)
             .checkERC20(_erc20Address);
@@ -200,9 +202,11 @@ contract OffsetHelper is OffsetHelperStorage {
         return false;
     }
 
-    /// @notice Checks whether an address can be used in a token swap
-    /// @param _erc20Address address of token to be checked
-    /// @return True if the specified address can be used in a swap
+    /**
+     * @notice Checks whether an address can be used in a token swap
+     * @param _erc20Address address of token to be checked
+     * @return True if the specified address can be used in a swap
+     */
     function isSwapable(address _erc20Address) private view returns (bool) {
         if (_erc20Address == eligibleTokenAddresses["USDC"]) return true;
         if (_erc20Address == eligibleTokenAddresses["WETH"]) return true;
@@ -210,9 +214,11 @@ contract OffsetHelper is OffsetHelperStorage {
         return false;
     }
 
-    /// @notice Checks whether an address is a Toucan pool token address
-    /// @param _erc20Address address of token to be checked
-    /// @return True if the address is a Toucan pool token address
+    /**
+     * @notice Checks whether an address is a Toucan pool token address
+     * @param _erc20Address address of token to be checked
+     * @return True if the address is a Toucan pool token address
+     */
     function isRedeemable(address _erc20Address) private view returns (bool) {
         if (_erc20Address == eligibleTokenAddresses["BCT"]) return true;
         if (_erc20Address == eligibleTokenAddresses["NCT"]) return true;
@@ -256,11 +262,13 @@ contract OffsetHelper is OffsetHelperStorage {
         return amountsIn[0];
     }
 
-    /// @notice uses SushiSwap to exchange eligible tokens for BCT / NCT
-    /// @param _fromToken token to deposit and swap
-    /// @param _toToken token to swap for (will be held within contract)
-    /// @param _amount amount of NCT / BCT wanted
-    /// @notice needs to be approved on the client side
+    /**
+     * @notice Swap eligible ERC20 tokens for Toucan pool tokens (BCT/NCT) on SushiSwap
+     * @dev Needs to be approved on the client side
+     * @param _fromToken token to deposit and swap
+     * @param _toToken token to swap for (will be held within contract)
+     * @param _amount amount of NCT / BCT wanted
+     */
     function swap(
         address _fromToken,
         address _toToken,
@@ -348,10 +356,11 @@ contract OffsetHelper is OffsetHelperStorage {
         return amounts[0];
     }
 
-    /// @notice uses SushiSwap to exchange MATIC for BCT / NCT
-    /// @param _toToken token to swap for (will be held within contract)
-    /// @param _amount amount of NCT / BCT wanted
-    /// @notice needs to be provided a message value on client side
+    /**
+     * @notice Swap MATIC for Toucan pool tokens (BCT/NCT) on SushiSwap
+     * @param _toToken token to swap for (will be held within contract)
+     * @param _amount amount of NCT / BCT wanted
+     */
     function swap(address _toToken, uint256 _amount) public payable {
         // check tokens
         require(isRedeemable(_toToken), "Token not eligible");
@@ -393,7 +402,9 @@ contract OffsetHelper is OffsetHelperStorage {
         balances[msg.sender][path[2]] += _amount;
     }
 
-    /// @notice allow users to withdraw tokens they have deposited
+    /**
+     * @notice allow users to withdraw tokens they have deposited
+     */
     function withdraw(address _erc20Addr, uint256 _amount) public {
         require(
             balances[msg.sender][_erc20Addr] >= _amount,
@@ -404,8 +415,10 @@ contract OffsetHelper is OffsetHelperStorage {
         balances[msg.sender][_erc20Addr] -= _amount;
     }
 
-    /// @notice allow people to deposit BCT / NCT
-    /// @notice needs to be approved
+    /**
+     * @notice allow people to deposit BCT / NCT
+     * @dev needs to be approved
+     */
     function deposit(address _erc20Addr, uint256 _amount) public {
         require(isRedeemable(_erc20Addr), "Token not eligible");
 
@@ -413,12 +426,14 @@ contract OffsetHelper is OffsetHelperStorage {
         balances[msg.sender][_erc20Addr] += _amount;
     }
 
-    /// @notice Redeems the specified amount of NCT / BCT for TCO2
-    /// @param _fromToken could be the address of NCT or BCT
-    /// @param _amount amount to redeem
-    /// @notice needs to be approved on the client side
-    /// @return tco2s an array of the TCO2 addresses that were redeemed
-    /// @return amounts an array of the amounts of each TCO2 that were redeemed
+    /**
+     * @notice Redeems the specified amount of NCT / BCT for TCO2
+     * @dev needs to be approved on the client side
+     * @param _fromToken could be the address of NCT or BCT
+     * @param _amount amount to redeem
+     * @return tco2s an array of the TCO2 addresses that were redeemed
+     * @return amounts an array of the amounts of each TCO2 that were redeemed
+     */
     function autoRedeem(address _fromToken, uint256 _amount)
         public
         returns (address[] memory tco2s, uint256[] memory amounts)
@@ -446,9 +461,11 @@ contract OffsetHelper is OffsetHelperStorage {
         emit Redeemed(msg.sender, _fromToken, tco2s, amounts);
     }
 
-    /// @notice Retire the specified TCO2 tokens.
-    /// @param _tco2s the addresses of the TCO2s to retire
-    /// @param _amounts the amounts to retire from the matching TCO2
+    /**
+     * @notice Retire the specified TCO2 tokens.
+     * @param _tco2s the addresses of the TCO2s to retire
+     * @param _amounts the amounts to retire from the matching TCO2
+     */
     function autoRetire(address[] memory _tco2s, uint256[] memory _amounts)
         public
     {
@@ -478,9 +495,11 @@ contract OffsetHelper is OffsetHelperStorage {
     //  Admin methods
     // ----------------------------------------
 
-    /// @notice you can use this to change or add eligible tokens and their addresses if needed
-    /// @param _tokenSymbol symbol of the token to add
-    /// @param _address the address of the token to add
+    /**
+     * @notice you can use this to change or add eligible tokens and their addresses if needed
+     * @param _tokenSymbol symbol of the token to add
+     * @param _address the address of the token to add
+     */
     function setEligibleTokenAddress(
         string memory _tokenSymbol,
         address _address
@@ -488,8 +507,10 @@ contract OffsetHelper is OffsetHelperStorage {
         eligibleTokenAddresses[_tokenSymbol] = _address;
     }
 
-    /// @notice you can use this to delete eligible tokens  if needed
-    /// @param _tokenSymbol symbol of the token to add
+    /**
+     * @notice you can use this to delete eligible tokens  if needed
+     * @param _tokenSymbol symbol of the token to add
+     */
     function deleteEligibleTokenAddress(string memory _tokenSymbol)
         public
         virtual
@@ -498,8 +519,10 @@ contract OffsetHelper is OffsetHelperStorage {
         delete eligibleTokenAddresses[_tokenSymbol];
     }
 
-    /// @notice you can use this to change the TCO2 contracts registry if needed
-    /// @param _address the contract registry to use
+    /**
+     * @notice you can use this to change the TCO2 contracts registry if needed
+     * @param _address the contract registry to use
+     */
     function setToucanContractRegistry(address _address)
         public
         virtual

--- a/docs/OffsetHelper.md
+++ b/docs/OffsetHelper.md
@@ -1,0 +1,357 @@
+# Solidity API
+
+## OffsetHelper
+
+Helper functions that simplify the carbon offsetting (retirement)
+process.
+
+Retiring carbon tokens normally requires multiple steps and interactions
+with Toucan Protocol's main contracts:
+1. Obtain a Toucan pool token such as BCT or NCT (by performing a token
+   swap).
+2. Redeem the pool token for a TCO2 token.
+3. Retire the TCO2 token.
+
+These steps are combined in each of the following "auto offset" methods
+implemented in `OffsetHelper` to allow a retirement within one transaction:
+- `autoOffsetUsingPoolToken()` if the user has already owns a Toucan pool
+  token such as BCT or NCT,
+- `autoOffsetUsingETH()` if the user would like to perform a retirement
+  using MATIC,
+- `autoOffsetUsingToken()` if the user would like to perform a retirement
+  using an ERC20 token: USDC, WETH or WMATIC.
+
+In these methods, "auto" refers to the fact that these methods use
+`autoRedeem` in order to automatically choose a TCO2 token corresponding
+to the oldest tokenized carbon project in the specfified token pool.
+There are no fees incurred by the user when using `autoRedeem`.
+
+There are two read helper functions `calculateNeededETHAmount()` and
+`calculateNeededTokenAmount()` that can be used before calling
+`autoOffsetUsingETH()` and `autoOffsetUsingToken()`, to determine how MATIC,
+respectively how much of the ERC20 token must be sent to the `OffsetHelper`
+contract in order to retire the specified amount of carbon.
+
+### constructor
+
+```solidity
+constructor(string[] _eligibleTokenSymbols, address[] _eligibleTokenAddresses) public
+```
+
+### Redeemed
+
+```solidity
+event Redeemed(address who, address poolToken, address[] tco2s, uint256[] amounts)
+```
+
+Emitted upon successful redemption of TCO2 tokens from a Toucan
+pool token such as BCT or NCT.
+
+| Name | Type | Description |
+| ---- | ---- | ----------- |
+| who | address | The sender of the transaction |
+| poolToken | address | The address of the Toucan pool token used in the redemption, for example, NCT or BCT |
+| tco2s | address[] | An array of the TCO2 addresses that were redeemed |
+| amounts | uint256[] | An array of the amounts of each TCO2 that were redeemed |
+
+### autoOffsetUsingToken
+
+```solidity
+function autoOffsetUsingToken(address _depositedToken, address _poolToken, uint256 _amountToOffset) public returns (address[] tco2s, uint256[] amounts)
+```
+
+Retire carbon credits using the lowest quality (oldest) TCO2
+tokens available from the specified Toucan token pool by sending ERC20
+tokens (USDC, WETH, WMATIC). Use `calculateNeededTokenAmount` first in
+order to find out how much of the ERC20 token is required to retire the
+specified quantity of TCO2.
+
+This function:
+1. Swaps the ERC20 token sent to the contract for the specified pool token.
+2. Redeems the pool token for the poorest quality TCO2 tokens available.
+3. Retires the TCO2 tokens.
+
+Note: The client must approve the ERC20 token that is sent to the contract.
+
+_When automatically redeeming pool tokens for the lowest quality
+TCO2s there are no fees and you receive exactly 1 TCO2 token for 1 pool
+token._
+
+| Name | Type | Description |
+| ---- | ---- | ----------- |
+| _depositedToken | address | The address of the ERC20 token that the user sends (must be one of USDC, WETH, WMATIC) |
+| _poolToken | address | The address of the Toucan pool token that the user wants to use, for example, NCT or BCT |
+| _amountToOffset | uint256 | The amount of TCO2 to offset |
+
+| Name | Type | Description |
+| ---- | ---- | ----------- |
+| tco2s | address[] | An array of the TCO2 addresses that were redeemed |
+| amounts | uint256[] | An array of the amounts of each TCO2 that were redeemed |
+
+### autoOffsetUsingETH
+
+```solidity
+function autoOffsetUsingETH(address _poolToken, uint256 _amountToOffset) public payable returns (address[] tco2s, uint256[] amounts)
+```
+
+Retire carbon credits using the lowest quality (oldest) TCO2
+tokens available from the specified Toucan token pool by sending MATIC.
+Use `calculateNeededETHAmount()` first in order to find out how much
+MATIC is required to retire the specified quantity of TCO2.
+
+This function:
+1. Swaps the Matic sent to the contract for the specified pool token.
+2. Redeems the pool token for the poorest quality TCO2 tokens available.
+3. Retires the TCO2 tokens.
+
+_If the user sends much MATIC, the leftover amount will be sent back
+to the user._
+
+| Name | Type | Description |
+| ---- | ---- | ----------- |
+| _poolToken | address | The address of the Toucan pool token that the user wants to use, for example, NCT or BCT. |
+| _amountToOffset | uint256 | The amount of TCO2 to offset. |
+
+| Name | Type | Description |
+| ---- | ---- | ----------- |
+| tco2s | address[] | An array of the TCO2 addresses that were redeemed |
+| amounts | uint256[] | An array of the amounts of each TCO2 that were redeemed |
+
+### autoOffsetUsingPoolToken
+
+```solidity
+function autoOffsetUsingPoolToken(address _poolToken, uint256 _amountToOffset) public returns (address[] tco2s, uint256[] amounts)
+```
+
+Retire carbon credits using the lowest quality (oldest) TCO2
+tokens available by sending Toucan pool tokens, for example, BCT or NCT.
+
+This function:
+1. Redeems the pool token for the poorest quality TCO2 tokens available.
+2. Retires the TCO2 tokens.
+
+Note: The client must approve the pool token that is sent.
+
+| Name | Type | Description |
+| ---- | ---- | ----------- |
+| _poolToken | address | The address of the Toucan pool token that the user wants to use, for example, NCT or BCT. |
+| _amountToOffset | uint256 | The amount of TCO2 to offset. |
+
+| Name | Type | Description |
+| ---- | ---- | ----------- |
+| tco2s | address[] | An array of the TCO2 addresses that were redeemed |
+| amounts | uint256[] | An array of the amounts of each TCO2 that were redeemed |
+
+### isEligible
+
+```solidity
+function isEligible(address _erc20Address) private view returns (bool)
+```
+
+Checks whether an address can be used by the contract.
+
+| Name | Type | Description |
+| ---- | ---- | ----------- |
+| _erc20Address | address | address of the ERC20 token to be checked |
+
+| Name | Type | Description |
+| ---- | ---- | ----------- |
+| [0] | bool | True if the address can be used by the contract |
+
+### isSwapable
+
+```solidity
+function isSwapable(address _erc20Address) private view returns (bool)
+```
+
+Checks whether an address can be used in a token swap
+
+| Name | Type | Description |
+| ---- | ---- | ----------- |
+| _erc20Address | address | address of token to be checked |
+
+| Name | Type | Description |
+| ---- | ---- | ----------- |
+| [0] | bool | True if the specified address can be used in a swap |
+
+### isRedeemable
+
+```solidity
+function isRedeemable(address _erc20Address) private view returns (bool)
+```
+
+Checks whether an address is a Toucan pool token address
+
+| Name | Type | Description |
+| ---- | ---- | ----------- |
+| _erc20Address | address | address of token to be checked |
+
+| Name | Type | Description |
+| ---- | ---- | ----------- |
+| [0] | bool | True if the address is a Toucan pool token address |
+
+### calculateNeededTokenAmount
+
+```solidity
+function calculateNeededTokenAmount(address _fromToken, address _toToken, uint256 _amount) public view returns (uint256)
+```
+
+Return how much of the specified ERC20 token is required in
+order to swap for the desired amount of a Toucan pool token, for
+example, BCT or NCT.
+
+| Name | Type | Description |
+| ---- | ---- | ----------- |
+| _fromToken | address | The address of the ERC20 token used for the swap |
+| _toToken | address | The address of the pool token to swap for, for example, NCT or BCT |
+| _amount | uint256 | The desired amount of pool token to receive |
+
+| Name | Type | Description |
+| ---- | ---- | ----------- |
+| [0] | uint256 | amountsIn The amount of the ERC20 token required in order to swap for the specified amount of the pool token |
+
+### swap
+
+```solidity
+function swap(address _fromToken, address _toToken, uint256 _amount) public
+```
+
+uses SushiSwap to exchange eligible tokens for BCT / NCT
+needs to be approved on the client side
+
+| Name | Type | Description |
+| ---- | ---- | ----------- |
+| _fromToken | address | token to deposit and swap |
+| _toToken | address | token to swap for (will be held within contract) |
+| _amount | uint256 | amount of NCT / BCT wanted |
+
+### fallback
+
+```solidity
+fallback() external payable
+```
+
+### receive
+
+```solidity
+receive() external payable
+```
+
+### calculateNeededETHAmount
+
+```solidity
+function calculateNeededETHAmount(address _toToken, uint256 _amount) public view returns (uint256)
+```
+
+Return how much MATIC is required in order to swap for the
+desired amount of a Toucan pool token, for example, BCT or NCT.
+
+| Name | Type | Description |
+| ---- | ---- | ----------- |
+| _toToken | address | The address of the pool token to swap for, for example, NCT or BCT |
+| _amount | uint256 | The desired amount of pool token to receive |
+
+| Name | Type | Description |
+| ---- | ---- | ----------- |
+| [0] | uint256 | amounts The amount of MATIC required in order to swap for the specified amount of the pool token |
+
+### swap
+
+```solidity
+function swap(address _toToken, uint256 _amount) public payable
+```
+
+uses SushiSwap to exchange MATIC for BCT / NCT
+needs to be provided a message value on client side
+
+| Name | Type | Description |
+| ---- | ---- | ----------- |
+| _toToken | address | token to swap for (will be held within contract) |
+| _amount | uint256 | amount of NCT / BCT wanted |
+
+### withdraw
+
+```solidity
+function withdraw(address _erc20Addr, uint256 _amount) public
+```
+
+allow users to withdraw tokens they have deposited
+
+### deposit
+
+```solidity
+function deposit(address _erc20Addr, uint256 _amount) public
+```
+
+allow people to deposit BCT / NCT
+needs to be approved
+
+### autoRedeem
+
+```solidity
+function autoRedeem(address _fromToken, uint256 _amount) public returns (address[] tco2s, uint256[] amounts)
+```
+
+Redeems the specified amount of NCT / BCT for TCO2
+needs to be approved on the client side
+
+| Name | Type | Description |
+| ---- | ---- | ----------- |
+| _fromToken | address | could be the address of NCT or BCT |
+| _amount | uint256 | amount to redeem |
+
+| Name | Type | Description |
+| ---- | ---- | ----------- |
+| tco2s | address[] | an array of the TCO2 addresses that were redeemed |
+| amounts | uint256[] | an array of the amounts of each TCO2 that were redeemed |
+
+### autoRetire
+
+```solidity
+function autoRetire(address[] _tco2s, uint256[] _amounts) public
+```
+
+Retire the specified TCO2 tokens.
+
+| Name | Type | Description |
+| ---- | ---- | ----------- |
+| _tco2s | address[] | the addresses of the TCO2s to retire |
+| _amounts | uint256[] | the amounts to retire from the matching TCO2 |
+
+### setEligibleTokenAddress
+
+```solidity
+function setEligibleTokenAddress(string _tokenSymbol, address _address) public virtual
+```
+
+you can use this to change or add eligible tokens and their addresses if needed
+
+| Name | Type | Description |
+| ---- | ---- | ----------- |
+| _tokenSymbol | string | symbol of the token to add |
+| _address | address | the address of the token to add |
+
+### deleteEligibleTokenAddress
+
+```solidity
+function deleteEligibleTokenAddress(string _tokenSymbol) public virtual
+```
+
+you can use this to delete eligible tokens  if needed
+
+| Name | Type | Description |
+| ---- | ---- | ----------- |
+| _tokenSymbol | string | symbol of the token to add |
+
+### setToucanContractRegistry
+
+```solidity
+function setToucanContractRegistry(address _address) public virtual
+```
+
+you can use this to change the TCO2 contracts registry if needed
+
+| Name | Type | Description |
+| ---- | ---- | ----------- |
+| _address | address | the contract registry to use |
+

--- a/docs/OffsetHelper.md
+++ b/docs/OffsetHelper.md
@@ -5,8 +5,8 @@
 Helper functions that simplify the carbon offsetting (retirement)
 process.
 
-Retiring carbon tokens normally requires multiple steps and interactions
-with Toucan Protocol's main contracts:
+Retiring carbon tokens requires multiple steps and interactions with
+Toucan Protocol's main contracts:
 1. Obtain a Toucan pool token such as BCT or NCT (by performing a token
    swap).
 2. Redeem the pool token for a TCO2 token.
@@ -14,7 +14,7 @@ with Toucan Protocol's main contracts:
 
 These steps are combined in each of the following "auto offset" methods
 implemented in `OffsetHelper` to allow a retirement within one transaction:
-- `autoOffsetUsingPoolToken()` if the user has already owns a Toucan pool
+- `autoOffsetUsingPoolToken()` if the user already owns a Toucan pool
   token such as BCT or NCT,
 - `autoOffsetUsingETH()` if the user would like to perform a retirement
   using MATIC,
@@ -22,21 +22,34 @@ implemented in `OffsetHelper` to allow a retirement within one transaction:
   using an ERC20 token: USDC, WETH or WMATIC.
 
 In these methods, "auto" refers to the fact that these methods use
-`autoRedeem` in order to automatically choose a TCO2 token corresponding
+`autoRedeem()` in order to automatically choose a TCO2 token corresponding
 to the oldest tokenized carbon project in the specfified token pool.
-There are no fees incurred by the user when using `autoRedeem`.
+There are no fees incurred by the user when using `autoRedeem()`, i.e., the
+user receives 1 TCO2 token for each pool token (BCT/NCT) redeemed.
 
-There are two read helper functions `calculateNeededETHAmount()` and
-`calculateNeededTokenAmount()` that can be used before calling
-`autoOffsetUsingETH()` and `autoOffsetUsingToken()`, to determine how MATIC,
-respectively how much of the ERC20 token must be sent to the `OffsetHelper`
-contract in order to retire the specified amount of carbon.
+There are two `view` helper functions `calculateNeededETHAmount()` and
+`calculateNeededTokenAmount()` that should be called before using
+`autoOffsetUsingETH()` and `autoOffsetUsingToken()`, to determine how much
+ MATIC, respectively how much of the ERC20 token must be sent to the
+`OffsetHelper` contract in order to retire the specified amount of carbon.
 
 ### constructor
 
 ```solidity
 constructor(string[] _eligibleTokenSymbols, address[] _eligibleTokenAddresses) public
 ```
+
+Contract constructor. Should specify arrays of ERC20 symbols and
+addresses that can used by the contract.
+
+_See `isEligible()` for a list of tokens that can be used in the
+contract. These can be modified after deployment by the contract owner
+using `setEligibleTokenAddress()` and `deleteEligibleTokenAddress()`._
+
+| Name | Type | Description |
+| ---- | ---- | ----------- |
+| _eligibleTokenSymbols | string[] | A list of token symbols. |
+| _eligibleTokenAddresses | address[] | A list of token addresses corresponding to the provided token symbols. |
 
 ### Redeemed
 
@@ -222,9 +235,9 @@ _Needs to be approved on the client side_
 
 | Name | Type | Description |
 | ---- | ---- | ----------- |
-| _fromToken | address | token to deposit and swap |
-| _toToken | address | token to swap for (will be held within contract) |
-| _amount | uint256 | amount of NCT / BCT wanted |
+| _fromToken | address | The ERC20 oken to deposit and swap |
+| _toToken | address | The token to swap for (will be held within contract) |
+| _amount | uint256 | The required amount of the Toucan pool token (NCT/BCT) |
 
 ### fallback
 
@@ -266,8 +279,8 @@ Swap MATIC for Toucan pool tokens (BCT/NCT) on SushiSwap
 
 | Name | Type | Description |
 | ---- | ---- | ----------- |
-| _toToken | address | token to swap for (will be held within contract) |
-| _amount | uint256 | amount of NCT / BCT wanted |
+| _toToken | address | Token to swap for (will be held within contract) |
+| _amount | uint256 | Amount of NCT / BCT wanted |
 
 ### withdraw
 
@@ -275,7 +288,7 @@ Swap MATIC for Toucan pool tokens (BCT/NCT) on SushiSwap
 function withdraw(address _erc20Addr, uint256 _amount) public
 ```
 
-allow users to withdraw tokens they have deposited
+Allow users to withdraw tokens they have deposited.
 
 ### deposit
 
@@ -283,9 +296,9 @@ allow users to withdraw tokens they have deposited
 function deposit(address _erc20Addr, uint256 _amount) public
 ```
 
-allow people to deposit BCT / NCT
+Allow users to deposit BCT / NCT.
 
-_needs to be approved_
+_Needs to be approved_
 
 ### autoRedeem
 
@@ -293,19 +306,19 @@ _needs to be approved_
 function autoRedeem(address _fromToken, uint256 _amount) public returns (address[] tco2s, uint256[] amounts)
 ```
 
-Redeems the specified amount of NCT / BCT for TCO2
+Redeems the specified amount of NCT / BCT for TCO2.
 
-_needs to be approved on the client side_
-
-| Name | Type | Description |
-| ---- | ---- | ----------- |
-| _fromToken | address | could be the address of NCT or BCT |
-| _amount | uint256 | amount to redeem |
+_Needs to be approved on the client side_
 
 | Name | Type | Description |
 | ---- | ---- | ----------- |
-| tco2s | address[] | an array of the TCO2 addresses that were redeemed |
-| amounts | uint256[] | an array of the amounts of each TCO2 that were redeemed |
+| _fromToken | address | Could be the address of NCT or BCT |
+| _amount | uint256 | Amount to redeem |
+
+| Name | Type | Description |
+| ---- | ---- | ----------- |
+| tco2s | address[] | An array of the TCO2 addresses that were redeemed |
+| amounts | uint256[] | An array of the amounts of each TCO2 that were redeemed |
 
 ### autoRetire
 
@@ -317,8 +330,8 @@ Retire the specified TCO2 tokens.
 
 | Name | Type | Description |
 | ---- | ---- | ----------- |
-| _tco2s | address[] | the addresses of the TCO2s to retire |
-| _amounts | uint256[] | the amounts to retire from the matching TCO2 |
+| _tco2s | address[] | The addresses of the TCO2s to retire |
+| _amounts | uint256[] | The amounts to retire from each of the corresponding TCO2 addresses |
 
 ### setEligibleTokenAddress
 
@@ -326,12 +339,12 @@ Retire the specified TCO2 tokens.
 function setEligibleTokenAddress(string _tokenSymbol, address _address) public virtual
 ```
 
-you can use this to change or add eligible tokens and their addresses if needed
+Change or add eligible tokens and their addresses.
 
 | Name | Type | Description |
 | ---- | ---- | ----------- |
-| _tokenSymbol | string | symbol of the token to add |
-| _address | address | the address of the token to add |
+| _tokenSymbol | string | The symbol of the token to add |
+| _address | address | The address of the token to add |
 
 ### deleteEligibleTokenAddress
 
@@ -339,11 +352,11 @@ you can use this to change or add eligible tokens and their addresses if needed
 function deleteEligibleTokenAddress(string _tokenSymbol) public virtual
 ```
 
-you can use this to delete eligible tokens  if needed
+Delete eligible tokens stored in the contract.
 
 | Name | Type | Description |
 | ---- | ---- | ----------- |
-| _tokenSymbol | string | symbol of the token to add |
+| _tokenSymbol | string | The symbol of the token to remove |
 
 ### setToucanContractRegistry
 
@@ -351,9 +364,9 @@ you can use this to delete eligible tokens  if needed
 function setToucanContractRegistry(address _address) public virtual
 ```
 
-you can use this to change the TCO2 contracts registry if needed
+Change the TCO2 contracts registry.
 
 | Name | Type | Description |
 | ---- | ---- | ----------- |
-| _address | address | the contract registry to use |
+| _address | address | The address of the Toucan contract registry to use |
 

--- a/docs/OffsetHelper.md
+++ b/docs/OffsetHelper.md
@@ -216,8 +216,9 @@ example, BCT or NCT.
 function swap(address _fromToken, address _toToken, uint256 _amount) public
 ```
 
-uses SushiSwap to exchange eligible tokens for BCT / NCT
-needs to be approved on the client side
+Swap eligible ERC20 tokens for Toucan pool tokens (BCT/NCT) on SushiSwap
+
+_Needs to be approved on the client side_
 
 | Name | Type | Description |
 | ---- | ---- | ----------- |
@@ -261,8 +262,7 @@ desired amount of a Toucan pool token, for example, BCT or NCT.
 function swap(address _toToken, uint256 _amount) public payable
 ```
 
-uses SushiSwap to exchange MATIC for BCT / NCT
-needs to be provided a message value on client side
+Swap MATIC for Toucan pool tokens (BCT/NCT) on SushiSwap
 
 | Name | Type | Description |
 | ---- | ---- | ----------- |
@@ -284,7 +284,8 @@ function deposit(address _erc20Addr, uint256 _amount) public
 ```
 
 allow people to deposit BCT / NCT
-needs to be approved
+
+_needs to be approved_
 
 ### autoRedeem
 
@@ -293,7 +294,8 @@ function autoRedeem(address _fromToken, uint256 _amount) public returns (address
 ```
 
 Redeems the specified amount of NCT / BCT for TCO2
-needs to be approved on the client side
+
+_needs to be approved on the client side_
 
 | Name | Type | Description |
 | ---- | ---- | ----------- |

--- a/docs/OffsetHelperStorage.md
+++ b/docs/OffsetHelperStorage.md
@@ -1,0 +1,28 @@
+# Solidity API
+
+## OffsetHelperStorage
+
+### eligibleTokenAddresses
+
+```solidity
+mapping(string => address) eligibleTokenAddresses
+```
+
+### contractRegistryAddress
+
+```solidity
+address contractRegistryAddress
+```
+
+### sushiRouterAddress
+
+```solidity
+address sushiRouterAddress
+```
+
+### balances
+
+```solidity
+mapping(address => mapping(address => uint256)) balances
+```
+

--- a/hardhat.config.ts
+++ b/hardhat.config.ts
@@ -6,10 +6,12 @@ import "@nomiclabs/hardhat-waffle";
 import "@typechain/hardhat";
 import "hardhat-gas-reporter";
 import "solidity-coverage";
+import "solidity-docgen";
 import { tokens } from "./utils/tokens";
 import addresses, { mumbaiAddresses } from "./utils/addresses";
 import { network } from "hardhat";
 import { boolean } from "hardhat/internal/core/params/argumentTypes";
+import { relative } from "path";
 
 dotenv.config();
 
@@ -102,6 +104,12 @@ const config: HardhatUserConfig = {
   },
   etherscan: {
     apiKey: process.env.POLYGONSCAN_API_KEY || "",
+  },
+  docgen: {
+    pages: (item: any, file: any) =>
+      file.absolutePath.startsWith("contracts/OffsetHelper")
+        ? relative("contracts", file.absolutePath).replace(".sol", ".md")
+        : undefined,
   },
 };
 

--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
     "prettier-plugin-solidity": "^1.0.0-beta.13",
     "solhint": "^3.3.7",
     "solidity-coverage": "^0.7.20",
+    "solidity-docgen": "^0.6.0-beta.16",
     "ts-node": "^10.7.0",
     "tslib": "^2.3.1",
     "typechain": "^5.2.0",

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
     "compile": "yarn hardhat compile",
     "console": "yarn hardhat console",
     "coverage": "yarn hardhat coverage --network hardhat",
+    "doc": "yarn hardhat docgen",
     "deploy": "yarn hardhat deploy",
     "test": "yarn hardhat test --network hardhat"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -5093,7 +5093,7 @@ growl@1.10.5:
   resolved "https://registry.yarnpkg.com/growl/-/growl-1.10.5.tgz#f2735dc2283674fa67478b10181059355c369e5e"
   integrity sha512-qBr4OuELkhPenW6goKVXiv47US3clb3/IbuWF9KNKEijAy9oeHxU9IgzjvJhHkUzhaj7rOUD7+YGWqUjLp5oSA==
 
-handlebars@^4.0.1:
+handlebars@^4.0.1, handlebars@^4.7.7:
   version "4.7.7"
   resolved "https://registry.yarnpkg.com/handlebars/-/handlebars-4.7.7.tgz#9ce33416aad02dbd6c8fafa8240d5d98004945a1"
   integrity sha512-aAcXm5OAfE/8IXkcZvCepKU3VzW1/39Fb5ZuqMtgI/hT8X2YgoMvBY5dLhq/cpOvw7Lk1nK/UF71aLG/ZnVYRA==
@@ -8620,6 +8620,11 @@ solhint@^3.3.7:
   optionalDependencies:
     prettier "^1.14.3"
 
+solidity-ast@^0.4.31:
+  version "0.4.32"
+  resolved "https://registry.yarnpkg.com/solidity-ast/-/solidity-ast-0.4.32.tgz#ba613ca24c7c79007798033e8a0f32a71285f09e"
+  integrity sha512-vCx17410X+NMnpLVyg6ix4NMCHFIkvWrJb1rPBBeQYEQChX93Zgb9WB9NaIY4zpsr3Q8IvAfohw+jmuBzGf8OQ==
+
 solidity-comments-extractor@^0.0.7:
   version "0.0.7"
   resolved "https://registry.yarnpkg.com/solidity-comments-extractor/-/solidity-comments-extractor-0.0.7.tgz#99d8f1361438f84019795d928b931f4e5c39ca19"
@@ -8648,6 +8653,14 @@ solidity-coverage@^0.7.20:
     semver "^7.3.4"
     shelljs "^0.8.3"
     web3-utils "^1.3.0"
+
+solidity-docgen@^0.6.0-beta.16:
+  version "0.6.0-beta.16"
+  resolved "https://registry.yarnpkg.com/solidity-docgen/-/solidity-docgen-0.6.0-beta.16.tgz#e38613107821057ef1baa3a75b121baebb2b24db"
+  integrity sha512-FD7aUWdbtkXW41T/4K+iNXrf7ab+OmAXulDOoD0aTonz76d4wmmFLSrAfoAIo0wm9nDyYiZ1Sw1KZ89Z8sAfEQ==
+  dependencies:
+    handlebars "^4.7.7"
+    solidity-ast "^0.4.31"
 
 source-map-resolve@^0.5.0:
   version "0.5.3"


### PR DESCRIPTION
This PR:
1. Moves any contract/method specific documentation out of the project's README and into the OffsetHelper contract's natspec comments.
2. Improves the contract's natspec documentation.
3. Adds a basic developer usage section to the README.
4. Enables markdown documentation generation from the natspec comments using [solidity-docgen](https://github.com/OpenZeppelin/solidity-docgen). Running `yarn doc` updates the markdown doc in `./docs/`.
5. Runs `yarn doc` as a Github action step to test that documentation generation is working.

Points 1. and 2. in this PR fixes #27.

Note: Currently the autogenerated doc is checked-in in the `./docs/` folder for convenience. We could consider generating html/publishing this to this repo's Github pages in a Github action in order to avoid the documentation becoming out of date.